### PR TITLE
ucloud: Fix default ssl_params value.

### DIFF
--- a/arduino_iot_cloud/ucloud.py
+++ b/arduino_iot_cloud/ucloud.py
@@ -175,7 +175,7 @@ class AIOTClient:
             device_id,
             username=None,
             password=None,
-            ssl_params=None,
+            ssl_params={},
             server="mqtts-sa.iot.oniudra.cc",
             port=8883,
             keepalive=10


### PR DESCRIPTION
* The ssl_params default value can't be None.