### PR TITLE
umqtt: Check if socket is None before trying to close it.

### DIFF
--- a/arduino_iot_cloud/umqtt.py
+++ b/arduino_iot_cloud/umqtt.py
@@ -150,7 +150,8 @@ class MQTTClient:
                 self._connect(clean_session)
                 return True
             except Exception as e:
-                self.sock.close()
+                if self.sock is not None:
+                    self.sock.close()
                 logging.warning(f"Connection failed {e}, retrying after {interval}s")
                 time.sleep(interval)
         return False


### PR DESCRIPTION
* If connect fails at resolving the address, sock can be None.