### PR TITLE
example: Add server and port parameters to connect using username and password

### DIFF
--- a/examples/micropython.py
+++ b/examples/micropython.py
@@ -36,7 +36,7 @@ def on_clight_changed(client, clight):
 async def main():
     # Create a client to connect to the Arduino IoT cloud. For MicroPython, the key and cert files must be stored
     # in DER format on the filesystem. Alternatively, a username and a password can be used for authentication:
-    #   client = AIOTClient(device_id, username="username", password="password")
+    #   client = AIOTClient(device_id=b"DEVICE_ID", username=b"DEVICE_ID", password=b"SECRET_KEY", server="mqtts-up.iot.oniudra.cc", port=8884)
     client = AIOTClient(device_id=DEVICE_ID, ssl_params={"keyfile": KEY_PATH, "certfile": CERT_PATH})
 
     # Register cloud objects. Note these objects must be created first in the dashboard.


### PR DESCRIPTION
To connect using username and password a different server url and port need to be used. 
`device_id` ad `username` are equal to the board `DEVICE_ID` assigned from the cloud. The password is named `SECRET_KEY` cloud side so i tought it was a good idea to rename it.

