### PR TITLE
ucloud: Set updated flag on update and init to push the initial values.

### DIFF
--- a/arduino_iot_cloud/ucloud.py
+++ b/arduino_iot_cloud/ucloud.py
@@ -110,12 +110,12 @@ class AIOTObject(SenmlRecord):
                     raise TypeError(
                         f"record: {self.name} invalid data type. Expected {type(self.value)} not {type(value)}"
                     )
-                self._updated = True
+            self._updated = True
             self.timestamp = timestamp()
-            if (self.value is None):
-                logging.info(f"Init: {self.name} value: {value} ts: {self.timestamp}")
-            else:
-                logging.debug(f"Update: {self.name} value: {value} ts: {self.timestamp}")
+            logging.debug(
+                f"%s: {self.name} value: {value} ts: {self.timestamp}"
+                % ("Init" if self.value is None else "Update")
+            )
         self._value = value
 
     def __getattr__(self, attr):


### PR DESCRIPTION
* Set the updated flag on updates and on initialization to push the initialized non-period variables to the cloud at least once.