### PR TITLE
misc: Add package file for mip installation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+    "urls": [
+      ["arduino_iot_cloud/__init__.py", "github:arduino/arduino-iot-cloud-py/src/arduino_iot_cloud/__init__.py"],
+      ["arduino_iot_cloud/ucloud.py", "github:arduino/arduino-iot-cloud-py/src/arduino_iot_cloud/ucloud.py"],
+      ["arduino_iot_cloud/umqtt.py", "github:arduino/arduino-iot-cloud-py/src/arduino_iot_cloud/umqtt.py"],
+      ["arduino_iot_cloud/ussl.py", "github:arduino/arduino-iot-cloud-py/src/arduino_iot_cloud/ussl.py"]
+    ],
+    "deps": [
+      ["senml", "0.1.0"]
+    ],
+    "version": "0.0.5"
+  }


### PR DESCRIPTION
This PR adds compatibility with the `mip` command (see [here](https://docs.micropython.org/en/latest/reference/packages.html)).
It's not clear to me if the `cbor` and `senml` packages are going to be hosted via the micropython-libs index. If so, the version specified in the dependencies may need to be adjusted accordingly.