### PR TITLE
ucloud: Callback name improvement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ client = ArduinoCloudClient(device_id=b"DEVICE_ID", username=b"DEVICE_ID", passw
 # Note: The following objects must be created first in the dashboard and linked to the device.
 # When the switch is toggled from the dashboard, the on_switch_changed function is called with
 # the client object and new value args.
-client.register("sw1", value=None, on_write=on_switch_changed)
+client.register("sw1", value=None, on_update_from_cloud=on_switch_changed)
 
-# The LED object is updated in the switch's on_write callback.
+# The LED object is updated in the switch's on_update_from_cloud callback.
 client.register("led", value=None)
 
 # 3. Start the Arduino cloud client.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ def on_switch_changed(client, value):
 # 1. Create a client object, which is used to connect to the IoT cloud and link local
 # objects to cloud objects. Note a username and password can be used for basic authentication
 # on both CPython and MicroPython. For more advanced authentication methods, please see the examples.
-client = AIOTClient(device_id=b"DEVICE_ID", username=b"DEVICE_ID", password=b"SECRET_KEY")
+client = ArduinoCloudClient(device_id=b"DEVICE_ID", username=b"DEVICE_ID", password=b"SECRET_KEY")
 
 # 2. Register cloud objects.
 # Note: The following objects must be created first in the dashboard and linked to the device.

--- a/examples/example.py
+++ b/examples/example.py
@@ -4,7 +4,7 @@
 import time
 import logging
 from time import strftime
-from arduino_iot_cloud import AIOTClient
+from arduino_iot_cloud import ArduinoCloudClient
 from arduino_iot_cloud import Location
 from arduino_iot_cloud import Schedule
 from arduino_iot_cloud import ColoredLight
@@ -59,8 +59,8 @@ if __name__ == "__main__":
     # To use a secure element, set the token's "pin" and URI in "keyfile" and "certfile", and
     # the CA certificate (if any) in "ssl_params". Alternatively, a username and password can
     # be used to authenticate, for example:
-    #   client = AIOTClient(device_id=b"DEVICE_ID", username=b"DEVICE_ID", password=b"SECRET_KEY")
-    client = AIOTClient(
+    #   client = ArduinoCloudClient(device_id=b"DEVICE_ID", username=b"DEVICE_ID", password=b"SECRET_KEY")
+    client = ArduinoCloudClient(
         device_id=DEVICE_ID,
         ssl_params={
             "pin": "1234",

--- a/examples/micropython.py
+++ b/examples/micropython.py
@@ -6,7 +6,7 @@ import ussl
 import network
 import logging
 from time import strftime
-from arduino_iot_cloud import AIOTClient
+from arduino_iot_cloud import ArduinoCloudClient
 from arduino_iot_cloud import Location
 from arduino_iot_cloud import Schedule
 from arduino_iot_cloud import ColoredLight
@@ -68,8 +68,8 @@ if __name__ == "__main__":
     # Create a client object to connect to the Arduino IoT cloud.
     # For MicroPython, the key and cert files must be stored in DER format on the filesystem.
     # Alternatively, a username and password can be used to authenticate:
-    #   client = AIOTClient(device_id=b"DEVICE_ID", username=b"DEVICE_ID", password=b"SECRET_KEY")
-    client = AIOTClient(
+    #   client = ArduinoCloudClient(device_id=b"DEVICE_ID", username=b"DEVICE_ID", password=b"SECRET_KEY")
+    client = ArduinoCloudClient(
         device_id=DEVICE_ID,
         ssl_params={
             "keyfile": KEY_PATH, "certfile": CERT_PATH, "cadata": CADATA, "cert_reqs": ussl.CERT_REQUIRED

--- a/src/arduino_iot_cloud/__init__.py
+++ b/src/arduino_iot_cloud/__init__.py
@@ -4,8 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from .ucloud import AIOTClient # noqa
-from .ucloud import AIOTObject
+from .ucloud import ArduinoCloudClient # noqa
+from .ucloud import ArduinoCloudObject
 from .ucloud import timestamp
 
 try:
@@ -36,27 +36,27 @@ CADATA = binascii.unhexlify(
 )
 
 
-class Location(AIOTObject):
+class Location(ArduinoCloudObject):
     def __init__(self, name, **kwargs):
         super().__init__(name, keys={"lat", "lon"}, **kwargs)
 
 
-class Color(AIOTObject):
+class Color(ArduinoCloudObject):
     def __init__(self, name, **kwargs):
         super().__init__(name, keys={"hue", "sat", "bri"}, **kwargs)
 
 
-class ColoredLight(AIOTObject):
+class ColoredLight(ArduinoCloudObject):
     def __init__(self, name, **kwargs):
         super().__init__(name, keys={"swi", "hue", "sat", "bri"}, **kwargs)
 
 
-class DimmedLight(AIOTObject):
+class DimmedLight(ArduinoCloudObject):
     def __init__(self, name, **kwargs):
         super().__init__(name, keys={"swi", "bri"}, **kwargs)
 
 
-class Schedule(AIOTObject):
+class Schedule(ArduinoCloudObject):
     def __init__(self, name, **kwargs):
         kwargs.update({("runnable", True)})  # Force task creation.
         self.on_active = kwargs.pop("on_active", None)
@@ -78,7 +78,7 @@ class Schedule(AIOTObject):
             await asyncio.sleep(self.interval)
 
 
-class Task(AIOTObject):
+class Task(ArduinoCloudObject):
     def __init__(self, name, **kwargs):
         kwargs.update({("runnable", True)})  # Force task creation.
         self.on_run = kwargs.pop("on_run", None)

--- a/src/arduino_iot_cloud/ucloud.py
+++ b/src/arduino_iot_cloud/ucloud.py
@@ -39,7 +39,7 @@ def timestamp():
 
 class ArduinoCloudObject(SenmlRecord):
     def __init__(self, name, **kwargs):
-        self.on_read = kwargs.pop("on_read", None)
+        self.on_send_to_cloud = kwargs.pop("on_send_to_cloud", None)
         self.on_write = kwargs.pop("on_write", None)
         self.interval = kwargs.pop("interval", 1.0)
         self._runnable = kwargs.pop("runnable", False)
@@ -84,7 +84,7 @@ class ArduinoCloudObject(SenmlRecord):
 
     @property
     def runnable(self):
-        return self.on_read is not None or self.on_write is not None or self._runnable
+        return self.on_send_to_cloud is not None or self.on_write is not None or self._runnable
 
     @SenmlRecord.value.setter
     def value(self, value):
@@ -149,8 +149,8 @@ class ArduinoCloudObject(SenmlRecord):
 
     async def run(self, client):
         while True:
-            if self.on_read is not None:
-                self.value = self.on_read(client)
+            if self.on_send_to_cloud is not None:
+                self.value = self.on_send_to_cloud(client)
             if self.on_write is not None and self.on_write_scheduled:
                 self.on_write_scheduled = False
                 self.on_write(client, self if isinstance(self.value, dict) else self.value)
@@ -254,8 +254,8 @@ class ArduinoCloudClient:
 
     def register(self, aiotobj, coro=None, **kwargs):
         if isinstance(aiotobj, str):
-            if kwargs.get("value", None) is None and kwargs.get("on_read", None) is not None:
-                kwargs["value"] = kwargs.get("on_read")(self)
+            if kwargs.get("value", None) is None and kwargs.get("on_send_to_cloud", None) is not None:
+                kwargs["value"] = kwargs.get("on_send_to_cloud")(self)
             aiotobj = ArduinoCloudObject(aiotobj, **kwargs)
 
         # Register the ArduinoCloudObject

--- a/src/arduino_iot_cloud/ucloud.py
+++ b/src/arduino_iot_cloud/ucloud.py
@@ -37,7 +37,7 @@ def timestamp():
     return int(time.time())
 
 
-class AIOTObject(SenmlRecord):
+class ArduinoCloudObject(SenmlRecord):
     def __init__(self, name, **kwargs):
         self.on_read = kwargs.pop("on_read", None)
         self.on_write = kwargs.pop("on_write", None)
@@ -46,7 +46,7 @@ class AIOTObject(SenmlRecord):
         value = kwargs.pop("value", None)
         if keys := kwargs.pop("keys", {}):
             value = {   # Create a complex object (with sub-records).
-                k: AIOTObject(f"{name}:{k}", value=v, callback=self.senml_callback)
+                k: ArduinoCloudObject(f"{name}:{k}", value=v, callback=self.senml_callback)
                 for (k, v) in {k: kwargs.pop(k, None) for k in keys}.items()
             }
         self._updated = False
@@ -157,7 +157,7 @@ class AIOTObject(SenmlRecord):
             await asyncio.sleep(self.interval)
 
 
-class AIOTClient:
+class ArduinoCloudClient:
     def __init__(
             self,
             device_id,
@@ -256,9 +256,9 @@ class AIOTClient:
         if isinstance(aiotobj, str):
             if kwargs.get("value", None) is None and kwargs.get("on_read", None) is not None:
                 kwargs["value"] = kwargs.get("on_read")(self)
-            aiotobj = AIOTObject(aiotobj, **kwargs)
+            aiotobj = ArduinoCloudObject(aiotobj, **kwargs)
 
-        # Register the AIOTObject
+        # Register the ArduinoCloudObject
         self.records[aiotobj.name] = aiotobj
 
         # Create a task for this object if it has any callbacks.


### PR DESCRIPTION
The current callback names, `on_read` and `on_write`, are confusing for a few reasons:

Ambiguity: These names do not clearly indicate the direction of the data flow or the action being performed. It's not apparent whether the reading or writing is happening on the client-side or the server-side. This ambiguity can lead to misunderstandings about the purpose and functionality of the callbacks.

Lack of context: The names on_read and on_write are generic and could apply to a wide range of scenarios, making it difficult to grasp their specific roles within this particular code. Without a clear context, developers may struggle to understand how these callbacks fit into the overall system.

Terminology inconsistency: The terms "read" and "write" are often associated with file I/O operations, which could lead to confusion when used within a context where data is being sent to and received from the cloud. By using more descriptive names, like on_send_to_cloud and on_update_from_cloud, it becomes easier to differentiate between local file operations and cloud data interactions.