### PR TITLE
ucloud: Fix asyncio imports to support recent upstream changes.

### DIFF
--- a/src/arduino_iot_cloud/ucloud.py
+++ b/src/arduino_iot_cloud/ucloud.py
@@ -10,14 +10,11 @@ from senml import SenmlPack
 from senml import SenmlRecord
 from arduino_iot_cloud.umqtt import MQTTClient
 
+import asyncio
+from asyncio import CancelledError
 try:
-    import asyncio
-    from asyncio import CancelledError
     from asyncio import InvalidStateError
-except ImportError:
-    import uasyncio as asyncio
-    from uasyncio.core import CancelledError
-
+except (ImportError, AttributeError):
     # MicroPython doesn't have this exception
     class InvalidStateError(Exception):
         pass


### PR DESCRIPTION
- Modules starting with u- prefix have been renamed upstream, this method to detect micropython by trying to import CPython modules first doesn't work anymore.