### PR TITLE
ucloud: Allow passing device id, username and password as strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Your `secrets.py` file should look like this:
 ```python
 WIFI_SSID  = ""  # WiFi network SSID (for MicroPython)
 WIFI_PASS  = ""  # WiFi network key  (for MicroPython)
-DEVICE_ID  = b"" # Provided by Arduino cloud when creating a device.
-SECRET_KEY = b"" # Provided by Arduino cloud when creating a device.
+DEVICE_ID  = "" # Provided by Arduino cloud when creating a device.
+SECRET_KEY = "" # Provided by Arduino cloud when creating a device.
 ```
 
 For more detailed examples and advanced API features, please see the [examples](https://github.com/arduino/arduino-iot-cloud-py/tree/main/examples).

--- a/src/arduino_iot_cloud/ucloud.py
+++ b/src/arduino_iot_cloud/ucloud.py
@@ -172,9 +172,18 @@ class ArduinoCloudClient:
         self.thing_id = None
         self.keepalive = keepalive
         self.last_ping = timestamp()
-        self.device_topic = b"/a/d/" + device_id + b"/e/i"
         self.senmlpack = SenmlPack("", self.senml_generic_callback)
         self.started = False
+
+        # Convert args to bytes if they are passed as strings.
+        if isinstance(device_id, str):
+            device_id = bytes(device_id, "utf-8")
+        if username is not None and isinstance(username, str):
+            username = bytes(username, "utf-8")
+        if password is not None and isinstance(password, str):
+            password = bytes(password, "utf-8")
+
+        self.device_topic = b"/a/d/" + device_id + b"/e/i"
 
         # Update RTC from NTP server on MicroPython.
         self.update_systime(ntp_server, ntp_timeout)


### PR DESCRIPTION
- Encode device id, username and password strings in cloud object instead of requiring them to be bytes.